### PR TITLE
Update hyper-native-tls to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ version = "~0.10.8"
 version = "~0.3"
 
 [dependencies.hyper-native-tls]
-version = "~0.2.2"
+version = "~0.3.0"


### PR DESCRIPTION
Hey and thanks for your work on this!

Unfortunately this library can't be currently built because it (transitively) depends on `security-framework = "^0.1.9"` and all versions in that range have been [yanked](https://crates.io/crates/security-framework/versions).

Update `hyper-native-tls to 0.3.0` which uses a newer, available version of `security-framework`.

I've run tests locally with *some* failures, but they seem more related to changes in Strava API than to this PR.